### PR TITLE
add explanation for private node IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ If you want to use the Hetzner Cloud `Networks` Feature, head over to
 the [Deployment with Networks support
 documentation](./docs/deploy_with_networks.md).
 
+If you manage the network yourself it might still be required to let the CCM know about private networks. You can do this by adding the environment variable
+with the network name/ID in the CCM deployment.
+
+```
+          env:
+            - name: HCLOUD_NETWORK
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: network
+```
+
+You also need to add the network name/ID to the secret: `kubectl -n kube-system create secret generic hcloud --from-literal=token=<hcloud API token> --from-literal=network=<hcloud Network_ID_or_Name>`.
+
 ## Versioning policy
 
 We aim to support the latest three versions of Kubernetes. After a new


### PR DESCRIPTION
The documentation lacks with regards to the deployment without Networks support. If you want to manage networks yourself but still make use of the private networks in hcloud there is a special case.

It is necessary to let the CCM know about the network so it can add the node IPs properly.